### PR TITLE
Pass through errors in store_utils.get_file_to_string

### DIFF
--- a/cravat/store_utils.py
+++ b/cravat/store_utils.py
@@ -188,14 +188,16 @@ def stream_to_file(
 
 
 def get_file_to_string(url):
-    try:
-        r = requests.get(url, timeout=(3, None))
-        if r.status_code == 200:
-            return r.text
-        else:
-            raise HTTPError(url, r.status_code, "", None, None)
-    except:
-        return ""
+    """
+    Sends a GET request to the given url and returns the response body as a string
+
+    Errors during the GET request are unhandled by this method
+    """
+    r = requests.get(url, timeout=(3, None))
+    if r.status_code == 200:
+        return r.text
+    else:
+        raise HTTPError(url, r.status_code, "", None, None)
 
 
 def file_checksum(path):


### PR DESCRIPTION
Fixes #121 

Basically has exceptions in `store_utils:get_file_to_string` bubble up instead of being suppressed and converted to an empty string with no useful debugging information.

- [ ] This PR still needs some work to verify that the places where this method is called are modified to handle the new contract.
