### PR TITLE
bugfix admin_util.py had a bug during dependency cleanup

### DIFF
--- a/cravat/admin_util.py
+++ b/cravat/admin_util.py
@@ -536,7 +536,7 @@ def __remove_locally_installed_deps(deps: dict) -> None:
         req = pkg_resources.Requirement(v_string)
         local_info = get_local_module_info(name)
         if local_info and local_info.version in req:
-            to_delete += deps[name]
+            to_delete += [name]
     
     # remove those matches
     for name in to_delete:


### PR DESCRIPTION

oc module install -y ancestrydna-converter
ERROR
'1'
Repeat command with --debug for more details

oc module install -y ancestrydna-converter --debug Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/cravat/oc.py", line 238, in main
    args.func(args)
  File "/usr/local/lib/python3.9/site-packages/cravat/cravat_admin.py", line 304, in install_modules
    deps = au.get_install_deps(module_name, version=version)
  File "/usr/local/lib/python3.9/site-packages/cravat/admin_util.py", line 598, in get_install_deps
    __remove_locally_installed_deps(deps)
  File "/usr/local/lib/python3.9/site-packages/cravat/admin_util.py", line 543, in __remove_locally_installed_deps
    del deps[name]
KeyError: '1'

The variable 
to_delete
needs to be a list of names. previously it was a long string of concatenated version details