### PR TITLE
Fix update all modules button functionality

### DIFF
--- a/cravat/webstore/nocache/webstore.js
+++ b/cravat/webstore/nocache/webstore.js
@@ -2342,9 +2342,7 @@ function onClickStoreUpdateAllButton() {
 }
 
 function announceStoreUpdatingAll() {
-    var span = document.getElementById('store-update-all-span');
     var button = document.getElementById('store-update-all-button');
-    span.textContent = 'Updating all available modules...';
     button.style.display = 'none';
 }
 

--- a/cravat/websubmit/nocache/core.js
+++ b/cravat/websubmit/nocache/core.js
@@ -24,7 +24,7 @@ function changePage (selectedPageId) {
         const pageIdDiv = pageIdDivs[i];
         const pageId = pageIdDiv.getAttribute('value');
         const page = document.getElementById(pageId);
-        if (page.id === selectedPageId) {
+        if (page && page.id === selectedPageId) {
             page.style.display = 'block';
             pageIdDiv.setAttribute('selval', 't');
             if (selectedPageId === 'storediv') {
@@ -33,8 +33,10 @@ function changePage (selectedPageId) {
                 OC.currentTab = 'submit';
             }
         } else {
-            page.style.display = 'none';
-            pageIdDiv.setAttribute('selval', 'f');
+            if (page) {
+                page.style.display = 'none';
+                pageIdDiv.setAttribute('selval', 'f');
+            }
         }
     }
 }


### PR DESCRIPTION
* The button handler was calling a helper that was setting status text (your modules are being downloaded) to a span that had been commented out and removed.
* This status text was removed entirely here

* Also fix an error in page navigation caused by the new single variant page linkout

#178 