### PR TITLE
Fix error in metrics when file system type cannot be found

### DIFF
--- a/cravat/cravat_metrics.py
+++ b/cravat/cravat_metrics.py
@@ -35,7 +35,11 @@ class cravatMetrics:
         self.machinedata['amountRAM'] = psutil.virtual_memory().total
         self.machinedata['swapMemory'] = psutil.swap_memory().total
         self.machinedata['numCPU'] = os.cpu_count()
-        self.machinedata['fileSystem'] = psutil.disk_partitions()[0].fstype
+        partitions = psutil.disk_partitions()
+        if len(partitions) > 0:
+            self.machinedata['fileSystem'] = psutil.disk_partitions()[0].fstype
+        else:
+            self.machinedata['fileSystem'] = 'unknown'
         self.machinedata['machineId'] = hex(uuid.getnode())
         self.machinedata['pythonVersion'] = platform.python_version()
 


### PR DESCRIPTION
Add workaround for wsl issue where `psutil` cannot find the disk filesystem