### PR TITLE
View error logs from GUI

### DIFF
--- a/cravat/websubmit/nocache/websubmit.css
+++ b/cravat/websubmit/nocache/websubmit.css
@@ -560,15 +560,13 @@ input:checked + .slider:before {
 .inactive-download-button {
   background-color: white;
   color: #c5af8d;
-  background-color: white;
   border: 1px solid #c5af8d;
   position: relative;
 }
 
 .inactive-download-button:hover {
-    background-color: #6e593a;
-    border: 1px solid #6e593a;
-    color: white;
+    background-color: white;
+    cursor: default;
 }
 
 .checkbox-container {

--- a/cravat/websubmit/nocache/websubmit.js
+++ b/cravat/websubmit/nocache/websubmit.js
@@ -571,15 +571,20 @@ function populateJobTr (job) {
     addEl(jobTr, dbTd);
     // Err
     var errLink = getEl('a');
-    errLink.setAttribute('href','/submit/jobs/' + job.id + '/err');
-    errLink.setAttribute('target', '_blank');
-    errLink.setAttribute('title', 'Check for per-variant errors.');
-    var errButton = getEl('button');
-    errButton.classList.add('butn');
-    errButton.classList.add('active-download-button');
-    addEl(errButton, getTn('Errors'));
-    addEl(errLink, errButton);
     addEl(dbTd, errLink);
+    var errButton = getEl('button');
+    addEl(errLink, errButton);
+    errButton.classList.add('butn');
+    if (job.num_error_input > 0) {
+        errButton.classList.add('active-download-button');
+        errLink.setAttribute('href','/submit/jobs/' + job.id + '/err');
+        errLink.setAttribute('target', '_blank');
+        errLink.setAttribute('title', 'View per-variant errors.');
+    } else {
+        errButton.classList.add('inactive-download-button');
+        errLink.setAttribute('title', 'No errors.');
+    }
+    addEl(errButton, getTn('Errors'));
     addEl(jobTr, dbTd);
     // + button
     var btn = getEl('button');

--- a/cravat/websubmit/nocache/websubmit.js
+++ b/cravat/websubmit/nocache/websubmit.js
@@ -562,12 +562,24 @@ function populateJobTr (job) {
     logLink.setAttribute('href','/submit/jobs/' + job.id + '/log');
     logLink.setAttribute('target', '_blank');
     logLink.setAttribute('title', 'Click to download.');
-    var button = getEl('button');
-    button.classList.add('butn');
-    button.classList.add('active-download-button');
-    addEl(button, getTn('Log'));
-    addEl(logLink, button);
+    var logButton = getEl('button');
+    logButton.classList.add('butn');
+    logButton.classList.add('active-download-button');
+    addEl(logButton, getTn('Log'));
+    addEl(logLink, logButton);
     addEl(dbTd, logLink);
+    addEl(jobTr, dbTd);
+    // Err
+    var errLink = getEl('a');
+    errLink.setAttribute('href','/submit/jobs/' + job.id + '/err');
+    errLink.setAttribute('target', '_blank');
+    errLink.setAttribute('title', 'Check for per-variant errors.');
+    var errButton = getEl('button');
+    errButton.classList.add('butn');
+    errButton.classList.add('active-download-button');
+    addEl(errButton, getTn('Errors'));
+    addEl(errLink, errButton);
+    addEl(dbTd, errLink);
     addEl(jobTr, dbTd);
     // + button
     var btn = getEl('button');


### PR DESCRIPTION
Add a button to the gui jobs table that links to the .err file. Button is only active if errors are present in job.

Fixes https://github.com/KarchinLab/open-cravat/issues/208