### PR TITLE
feat/hgvs converter: Add supporting features for HGVS converter

### DIFF
--- a/cravat/base_converter.py
+++ b/cravat/base_converter.py
@@ -1,3 +1,6 @@
+from cravat.config_loader import ConfigLoader
+
+
 class BaseConverter(object):
     IGNORE = "converter_ignore"
 
@@ -6,6 +9,9 @@ class BaseConverter(object):
         self.output_dir = None
         self.run_name = None
         self.input_assembly = None
+        self.module_name = self.__class__.__module__
+        config_loader = ConfigLoader()
+        self.conf = config_loader.get_module_conf(self.module_name)
 
     def check_format(self, *args, **kwargs):
         err_msg = (

--- a/cravat/cravat_convert.py
+++ b/cravat/cravat_convert.py
@@ -260,6 +260,7 @@ class MasterCravatConverter(object):
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
             converter = module.CravatConverter()
+            converter.input_assembly = self.input_assembly
             if converter.format_name not in self.converters:
                 self.converters[converter.format_name] = converter
             else:


### PR DESCRIPTION
Small changes to BaseConverter and MasterCravatConverter in order to pass the converter's yml config to the CravatConverter object, and to set the input_assembly of the CravatConverter. This will allow converters (specifically the HGVSConverter) to access configurations of APIs or other necessities, and to check on a per-line basis that the input variant is on the correct assembly.