### PR TITLE
OC-556 Add a discretize_scalar utility function

### DIFF
--- a/cravat/util.py
+++ b/cravat/util.py
@@ -18,6 +18,24 @@ from types import SimpleNamespace
 import math
 
 
+def discretize_scalar(score, cutoffs):
+    """Locate the location of `score` in a list[tuple(float, str)] of
+    `cutoffs`, where the float cutoff is the maximum value, inclusive
+    of the value, for that label. The last tuple should typically have
+    `float("inf")` as the cutoff, otherwise the function may retun
+    `None`
+
+    The cutoffs must be sorted in increasing value.
+    """
+    prev_cutoff = None
+    for cutoff, label in cutoffs:
+        if score <= cutoff:
+            return label
+        if prev_cutoff is not None and prev_cutoff > cutoff:
+            raise ValueError("cutoffs are not sorted")
+        prev_cutoff = cutoff
+
+
 def get_ucsc_bins(start, stop=None):
     if stop is None:
         stop = start + 1


### PR DESCRIPTION
The calibrated annotators all need a function to convert a floating point number into corresponding bins.

@kylemoad we discussed going this route for additional calibrations:
- add this function to open-cravat
- bump the open-cravat version
- add the new calibrations, with a version requirement on the annotators for this

With further discussion, we decided to include the function in the VEP module code, check for existence in the main open cravat.util package and use that if available and override the local function if so. Then eventually we can remove the old code on a future VEP update.