### PR TITLE
migrate away from deprecated `pkg_resources`

### DIFF
--- a/cravat/base_mapper.py
+++ b/cravat/base_mapper.py
@@ -11,16 +11,10 @@ from .constants import (
     crg_idx,
     crt_def,
     crt_idx,
-    gene_level_so_exclude,
 )
-from .exceptions import InvalidData, NoVariantError
 from cravat.config_loader import ConfigLoader
-import sys
-import pkg_resources
+import importlib.metadata
 import json
-import cravat.cravat_util as cu
-from types import SimpleNamespace
-import multiprocessing as mp
 import cravat.admin_util as au
 import time
 import cravat.util
@@ -77,7 +71,7 @@ class BaseMapper(object):
         self._setup_logger()
         config_loader = ConfigLoader()
         self.conf = config_loader.get_module_conf(self.module_name)
-        self.cravat_version = pkg_resources.get_distribution("open-cravat").version
+        self.cravat_version = importlib.metadata.distribution("open-cravat").version
 
     def _define_main_cmd_args(self):
         self.cmd_parser = argparse.ArgumentParser()

--- a/cravat/store_utils.py
+++ b/cravat/store_utils.py
@@ -10,7 +10,7 @@ import hashlib
 import zipfile
 from . import exceptions
 import json
-import pkg_resources
+import importlib.metadata
 from urllib.error import HTTPError
 import types
 
@@ -89,7 +89,7 @@ class PathBuilder(object):
 
     def manifest(self, version=None):
         if version is None:
-            version = pkg_resources.get_distribution("open-cravat").version
+            version = importlib.metadata.distribution("open-cravat").version
         fname = "manifest-{}.yml".format(version)
         return self._build_path(self.base(), fname)
 

--- a/cravat/util.py
+++ b/cravat/util.py
@@ -13,7 +13,7 @@ import logging
 from distutils.version import LooseVersion
 from cravat.cravat_util import max_version_supported_for_migration
 import sqlite3
-import pkg_resources
+import importlib.metadata
 import datetime
 import argparse
 from types import SimpleNamespace
@@ -419,7 +419,7 @@ def detect_encoding(path):
 def is_compatible_version(dbpath):
     db = sqlite3.connect(dbpath)
     c = db.cursor()
-    oc_version = LooseVersion(pkg_resources.get_distribution("open-cravat").version)
+    oc_version = LooseVersion(importlib.metadata.distribution("open-cravat").version)
     sql = 'select colval from info where colkey="open-cravat"'
     c.execute(sql)
     r = c.fetchone()


### PR DESCRIPTION
Recent python versions print out scary messages about pkg_resources going away soon. This probably isn't a big issue, but I spent a few minutes looking at our options. This PR has not yet been extensively tested, but serves as the start of the process.

There's a [migration guide](https://importlib-metadata.readthedocs.io/en/latest/migration.html) but it doesn't cover many of of the uses directly. There are broadly two classes of use in OpenCravat, getting the version and referring to Requirements.

```grep
./util.py:16:import pkg_resources
./util.py:422:    oc_version = LooseVersion(pkg_resources.get_distribution("open-cravat").version)
```

```grep
./store_utils.py:13:import pkg_resources
./store_utils.py:92:            version = pkg_resources.get_distribution("open-cravat").version
```

```grep
./base_mapper.py:19:import pkg_resources
./base_mapper.py:80:        self.cravat_version = pkg_resources.get_distribution("open-cravat").version
```

```grep
./store_utils.py:13:import pkg_resources
./store_utils.py:92:            version = pkg_resources.get_distribution("open-cravat").version
```

```grep
./admin_util.py:15:import pkg_resources
./admin_util.py:495:    version = pkg_resources.get_distribution("open-cravat").version
```

The new package is `packaging.requirements` for `Requirement`:

[https://packaging.pypa.io/en/stable/requirements.html](https://packaging.pypa.io/en/stable/requirements.html)

The uses of `Requirement` need the `in` operator in these instances:

```grep
./admin_util.py:521:def __get_highest_matching_version(requirement: pkg_resources.Requirement, versions: list) -> str:
./admin_util.py:537:        req = pkg_resources.Requirement(v_string)
./admin_util.py:591:        r = pkg_resources.Requirement(full_req_string)

```

The following instantiation subsequently uses `req.name` and `req.specifier`. These are both in `packaging.requirements`:

```grep
./admin_util.py:560:        req = pkg_resources.Requirement(req_string)
```

The following function creates `Requirement` objects but does not use any attributes of them, and returns data structures around them. The function `get_updateable` is called in two other places. First, in cravat_admin.py where it doesn't use any attributes of the `Requirement` objects. And then in webstore.py, where the `Requirement` objects get converted to a string.

```grep
./admin_util.py:972:        reqs = [pkg_resources.Requirement(s) for s in req_strings]
```