### PR TITLE
mac build: fix shebang modification

### DIFF
--- a/.build/mac/make.sh
+++ b/.build/mac/make.sh
@@ -37,4 +37,4 @@ cp $APPDIR/Contents/Info.plist $RESDIR/Info.plist.bak
 plutil -replace CFBundleShortVersionString -string $1 $APPDIR/Contents/Info.plist
 
 cd $RESDIR/bin
-sed -i '' "s=${ENVDIR}/bin/python=/usr/bin/env python -I=g" oc
+sed -i '' e '1s=^.*python=#!/usr/bin/env python=' -e '1s/$/ -I/' oc


### PR DESCRIPTION
Issue #362 found that the macOS installer creates a shell executable python script with a mangled `#!` first line:

```python
#!/usr/bin/env python -I3.11
# -*- coding: utf-8 -*-
import re
import sys
from cravat.oc import main
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(main())
```

It looks like prior versions only had `ENVDIR/bin/python` specified by the environment, but recent versions specify a full `ENVDIR/bin/python3.11`, breaking a sed script. This commit fixes the sed line change.

To test:
- [x] run github build action and test resulting pacakge