### PR TITLE
Added CI status badge and title to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Open-CRAVAT
+
+[![Publish Release](https://github.com/KarchinLab/open-cravat/actions/workflows/build-and-publish.yml/badge.svg)](https://github.com/KarchinLab/open-cravat/actions/workflows/build-and-publish.yml)
+
 Open-CRAVAT is a python package that performs genomic variant interpretation including variant impact, annotation, and scoring.  It has a modular architecture with a wide variety of analysis modules that are developed both by the CRAVAT team and the broader variant analysis community. Open-CRAVAT is a product of the [Karchin Lab](http://karchinlab.org/) at Johns Hopkins University with funding provided by the National Cancer Institute's [ITCR](https://itcr.cancer.gov/) program.
 
 # Links


### PR DESCRIPTION
This PR adds the missing CI status badge to the README and improves documentation structure by adding a proper H1 title. These changes enhance readability and provide quick visibility into the CI status.