### PR TITLE
Lock version of chardet package to <6.0.0

### DIFF
--- a/cravat/admin_util.py
+++ b/cravat/admin_util.py
@@ -559,7 +559,7 @@ def __remove_locally_installed_deps(deps: dict) -> None:
         v_string = f"{name}>={version}"
         req = packaging.requirements.Requirement(v_string)
         local_info = get_local_module_info(name)
-        if local_info and local_info.version in req:
+        if local_info and local_info.version in req.specifier:
             to_delete.append(name)
     
     # remove those matches

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
               },
     install_requires=[
         'looseversion',
-        'packaging',
+        'packaging>=25.0.0',
         'pyyaml',
         'requests',
         'requests-toolbelt',


### PR DESCRIPTION
* python `requests` checks for both `chardet` and `charset_normalizer`, but chardet is not in the `setup.py` for `requests`
* in `requests.__init__` when it looks for `chardet`, it looks for version < 6
* this change pins our `chardet` version < 6 to prevent this error from `requests`