### PR TITLE
[OC-760] Module directory version freeze & install

### DIFF
--- a/cravat/cravat_admin.py
+++ b/cravat/cravat_admin.py
@@ -168,6 +168,22 @@ def list_modules(args):
     else:
         list_local_modules(pattern=args.pattern, types=args.types, include_hidden=args.include_hidden, tags=args.tags, quiet=args.quiet, raw_bytes=args.raw_bytes)
 
+def freeze_modules(args):
+    import json
+    if args.md is not None:
+        constants.custom_modules_dir = args.md
+    modules = []
+    for module_name in au.search_local(r'.*'):
+        module_info = au.get_local_module_info(module_name)
+        if module_info.hidden and not args.include_hidden:
+            continue
+        modules.append({
+            'name': module_info.name,
+            'version': module_info.version,
+            'type': module_info.type,
+        })
+    print(json.dumps(modules, indent=2))
+
 def yaml_string(x):
     s = yaml.dump(x, default_flow_style = False)
     s = re.sub('!!.*', '', s)
@@ -713,6 +729,18 @@ parser_ls.add_argument('--md',
     help='Specify the root directory of OpenCRAVAT modules'
 )
 parser_ls.set_defaults(func=list_modules)
+
+# freeze
+parser_freeze = subparsers.add_parser('freeze',
+    help='Output installed modules as JSON.',
+    description='Output installed modules as JSON.')
+parser_freeze.add_argument('-i', '--include-hidden',
+    action='store_true',
+    help='Include hidden modules')
+parser_freeze.add_argument('--md',
+    default=None,
+    help='Specify the root directory of OpenCRAVAT modules')
+parser_freeze.set_defaults(func=freeze_modules)
 
 # publish
 parser_publish = subparsers.add_parser('publish',

--- a/cravat/cravat_admin.py
+++ b/cravat/cravat_admin.py
@@ -184,6 +184,40 @@ def freeze_modules(args):
         })
     print(json.dumps(modules, indent=2))
 
+def install_freeze_modules(args):
+    import json, sys
+    if args.md is not None:
+        constants.custom_modules_dir = args.md
+    src = sys.stdin if args.freeze_file == '-' else open(args.freeze_file)
+    with src:
+        modules = json.load(src)
+    to_install = {entry['name']: entry['version'] for entry in modules}
+    if not to_install:
+        print('No modules in freeze file')
+        return
+    print('Installing: {}'.format(
+        ', '.join(f"{n}:{v}" for n, v in sorted(to_install.items()))
+    ))
+    if not args.yes:
+        while True:
+            resp = input('Proceed? ([y]/n) > ')
+            if resp in ('y', ''):
+                break
+            if resp == 'n':
+                return
+    for module_name, module_version in sorted(to_install.items()):
+        stage_handler = InstallProgressStdout(module_name, module_version)
+        au.install_module(
+            module_name,
+            version=module_version,
+            force_data=False,
+            stage_handler=stage_handler,
+            force=args.force,
+            skip_data=False,
+            install_pypi_dependency=True,
+        )
+    Module.invalidate_cache()
+
 def yaml_string(x):
     s = yaml.dump(x, default_flow_style = False)
     s = re.sub('!!.*', '', s)
@@ -741,6 +775,26 @@ parser_freeze.add_argument('--md',
     default=None,
     help='Specify the root directory of OpenCRAVAT modules')
 parser_freeze.set_defaults(func=freeze_modules)
+
+# install-freeze
+parser_install_freeze = subparsers.add_parser('install-freeze',
+    help='Install modules from a freeze file.',
+    description='Install modules from a freeze file (JSON output of the freeze command).')
+parser_install_freeze.add_argument('freeze_file',
+    help='Path to freeze JSON file, or - to read from stdin')
+parser_install_freeze.add_argument('-f', '--force',
+    action='store_true',
+    help='Reinstall even if the correct version is already installed')
+parser_install_freeze.add_argument('-y', '--yes',
+    action='store_true',
+    help='Proceed without prompt')
+parser_install_freeze.add_argument('--skip-dependencies',
+    action='store_true',
+    help='Skip installing dependencies')
+parser_install_freeze.add_argument('--md',
+    default=None,
+    help='Specify the root directory of OpenCRAVAT modules')
+parser_install_freeze.set_defaults(func=install_freeze_modules)
 
 # publish
 parser_publish = subparsers.add_parser('publish',

--- a/cravat/oc.py
+++ b/cravat/oc.py
@@ -72,6 +72,12 @@ module_install_base_base_p = module_sp.add_parser(
     add_help=False,
     help="Install base modules",
 )
+module_freeze_p = module_sp.add_parser(
+    "freeze",
+    parents=[cravat_admin.parser_freeze],
+    add_help=False,
+    help="Output installed modules as JSON",
+)
 
 
 # config

--- a/cravat/oc.py
+++ b/cravat/oc.py
@@ -79,6 +79,13 @@ module_freeze_p = module_sp.add_parser(
     help="Output installed modules as JSON",
 )
 
+module_install_freeze_p = module_sp.add_parser(
+    "install-freeze",
+    parents=[cravat_admin.parser_install_freeze],
+    add_help=False,
+    help="Install modules from a freeze file",
+)
+
 
 # config
 config_p = root_sp.add_parser(


### PR DESCRIPTION
Add `oc module freeze` and `oc module install-freeze` commands

Implements a pip-style freeze/restore workflow for OpenCRAVAT modules.

`oc module freeze` outputs all installed modules as a JSON array with
name, version, and type fields. Use `-i`/`--include-hidden` to include
hidden modules. Output goes to stdout and can be redirected to a file.

`oc module install-freeze` reads a freeze JSON file and installs the
pinned versions. Analogous to `pip install -r requirements.txt`.

Options for `oc module freeze`:
-  `-i`, `--include-hidden`  Include hidden modules in output
- `--md MD`               Specify the root directory of OpenCRAVAT modules

Options for `oc module install-freeze`:
-  `freeze_file`           Path to freeze JSON file, or - to read from stdin
-  `-f`, `--force`           Reinstall even if the correct version is already installed
-  `-y`, `--yes`             Proceed without prompt
-  `--skip-dependencies`   Skip installing dependencies
-  `--md MD`               Specify the root directory of OpenCRAVAT modules

Example usage:

```bash
  # Save current module state
  oc module freeze > modules.json

  # Restore pinned modules on another system
  oc module install-freeze modules.json

  # Non-interactive restore
  oc module install-freeze -y modules.json

  # Pipe directly (no intermediate file)
  oc module freeze | oc module install-freeze -

  # Force reinstall of all pinned versions
  oc module install-freeze -f -y modules.json
```