### PR TITLE
feat/remove force data

### DIFF
--- a/cravat/cravat_admin.py
+++ b/cravat/cravat_admin.py
@@ -409,12 +409,11 @@ def publish_module (args):
 
 def install_base (args):
     args = SimpleNamespace(modules=constants.base_modules,
-        force_data=args.force_data,
+        force_data=args.force,
         version=None,
         yes=True,
         private=False,
         skip_dependencies=False,
-        force=args.force,
         skip_data=False,
         install_pypi_dependency=args.install_pypi_dependency,
         md=args.md,
@@ -529,11 +528,7 @@ parser_install_base = subparsers.add_parser('install-base',
 )
 parser_install_base.add_argument('-f','--force',
     action='store_true',
-    help='Overwrite existing modules',
-)
-parser_install_base.add_argument('-d', '--force-data',
-    action='store_true',
-    help='Download data even if latest data is already installed'
+    help='Overwrite existing modules and re-download data',
 )
 parser_install_base.add_argument('--install-pypi-dependency',
     action='store_true',

--- a/cravat/cravat_admin.py
+++ b/cravat/cravat_admin.py
@@ -322,9 +322,8 @@ def install_modules(args):
             au.install_module(
                 module_name,
                 version=module_version,
-                force_data=args.force_data,
+                force_data=args.force,
                 stage_handler=stage_handler,
-                force=args.force,
                 skip_data=args.skip_data,
                 install_pypi_dependency=args.install_pypi_dependency
             )
@@ -569,11 +568,7 @@ help='Install a specific version'
 )
 parser_install.add_argument('-f','--force',
 action='store_true',
-help='Install module even if latest version is already installed',
-)
-parser_install.add_argument('-d', '--force-data',
-action='store_true',
-help='Download data even if latest data is already installed'
+help='Install module even if latest version is already installed. Forces a re-download of data even if latest is already installed. Use --skip-data to not re-download.',
 )
 parser_install.add_argument('-y','--yes',
 action='store_true',


### PR DESCRIPTION
Remove the --force-data option from oc module install.
Let -f/--force always redownload and install data.
Use --skip-data if data is not needed.