### PR TITLE
Feat/queue limits

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -44,7 +44,7 @@ RUN mv $PACKAGEDIR/conf         /mnt/conf         && ln -s /mnt/conf         $PA
     mv $PACKAGEDIR/logs         /mnt/logs         && ln -s /mnt/logs         $PACKAGEDIR/logs    && \
     mv $PACKAGEDIR/workspace    /mnt/workspace    && ln -s /mnt/workspace    $PACKAGEDIR/workspace
 
-ENV CRAVAT_HOME $PACKAGEDIR
+ENV CRAVAT_HOME=$PACKAGEDIR
 
 VOLUME /mnt/conf
 VOLUME /mnt/modules
@@ -54,4 +54,3 @@ VOLUME /mnt/workspace
 
 VOLUME /tmp/job
 WORKDIR /tmp/job
-

--- a/cravat/cravat_web.py
+++ b/cravat/cravat_web.py
@@ -33,6 +33,11 @@ import time
 import cravat.util
 import threading
 from pathlib import Path
+from cravat.gui.workers import (
+    default_worker,
+    store_worker,
+    live_annotation_worker,
+)
 
 
 SERVER_ALREADY_RUNNING = -1
@@ -241,26 +246,6 @@ def run(args):
     else:
         run_flask(args)
 
-
-def default_celery_worker():
-    from cravat.gui import celery
-
-    worker = celery.Worker(queue='default')
-    worker.start()
-
-
-def store_worker():
-    from cravat.gui import celery
-
-    worker = celery.Worker(queue="module_install", concurrency=1)
-    worker.start()
-
-
-def live_annotation_worker():
-    from cravat.gui import celery
-    worker = celery.Worker(queue="live_annotate", concurrency=16)
-    worker.start()
-
 def open_browser(url, delay=1):
     def _open():
         time.sleep(delay)
@@ -283,7 +268,7 @@ def run_flask(args):
     cache.cache.clear()
 
     from multiprocessing import Process
-    p = Process(target=default_celery_worker)
+    p = Process(target=default_worker)
     p.start()
 
     p2 = Process(target=store_worker)

--- a/cravat/gui/api/handlers.py
+++ b/cravat/gui/api/handlers.py
@@ -1,5 +1,6 @@
 from flask import request, g, abort
 from cravat.gui import tasks
+from cravat.gui.config import QUEUE_LIVE_ANNOTATE, celery_settings
 import cravat.admin_util as au
 
 ## LIVE ANNOTATION
@@ -12,8 +13,7 @@ def format_response(response, version):
         return response
 
 def live_annotate(version=None):
-    enable_variant_api = au.get_system_conf().get('enable_variant_api',False)
-    if not enable_variant_api:
+    if not celery_settings()[QUEUE_LIVE_ANNOTATE]['enabled']:
         return abort(404)
     queries = dict(request.values) if request.values else request.json
     annotators = queries.get('annotators', [])

--- a/cravat/gui/config.py
+++ b/cravat/gui/config.py
@@ -4,9 +4,32 @@ from kombu import Exchange, Queue
 ## WHere is this used can we use system conf
 CRAVAT_SYSCONF = admin_util.get_system_conf()
 
-default_exchange = Exchange('default', type='direct')
-management_exchange = Exchange('management', type='direct')
-live_annotate_exchange = Exchange('live_annotate', type='direct')
+# Celery queue names used by the GUI
+QUEUE_DEFAULT = 'default'
+QUEUE_MODULE_INSTALL = 'module_install'
+QUEUE_LIVE_ANNOTATE = 'live_annotate'
+
+def celery_settings():
+    user = CRAVAT_SYSCONF.get('celery') or {}
+    # Configurable value defaults
+    queue_defaults = {
+        QUEUE_DEFAULT: {'concurrency': 4},
+        QUEUE_LIVE_ANNOTATE: {'enabled': False, 'concurrency': 4},
+    }
+    # Module install queue not user configurable
+    merged = {
+        QUEUE_MODULE_INSTALL: {'concurrency': 1},
+    }
+    for queue, defaults in queue_defaults.items():
+        q = dict(defaults)
+        q.update(user.get(queue) or {})
+        merged[queue] = q
+    return merged
+
+# Celery exchanges exist per-queue
+default_exchange = Exchange(QUEUE_DEFAULT, type='direct')
+module_install_exchange = Exchange(QUEUE_MODULE_INSTALL, type='direct')
+live_annotate_exchange = Exchange(QUEUE_LIVE_ANNOTATE, type='direct')
 
 # COOKIE CONFIGURATION (https://flask.palletsprojects.com/en/2.3.x/config/)
 
@@ -44,13 +67,13 @@ CELERY = dict(
     result_backend=f'file:/{CELERY_RESULTS_PATH}',
     include=['cravat.gui.tasks'],
     task_queues=(
-        Queue('default', default_exchange, routing_key='default'),
-        Queue('module_install', management_exchange, routing_key='module_install'),
-        Queue('live_annotate', live_annotate_exchange, routing_key='live_annotate'),
+        Queue(QUEUE_DEFAULT, default_exchange, routing_key=QUEUE_DEFAULT),
+        Queue(QUEUE_MODULE_INSTALL, module_install_exchange, routing_key=QUEUE_MODULE_INSTALL),
+        Queue(QUEUE_LIVE_ANNOTATE, live_annotate_exchange, routing_key=QUEUE_LIVE_ANNOTATE),
     ),
-    task_default_queue='default',
-    task_default_exchange='default',
-    task_default_routing_key='default'
+    task_default_queue=QUEUE_DEFAULT,
+    task_default_exchange=QUEUE_DEFAULT,
+    task_default_routing_key=QUEUE_DEFAULT,
 )
 
 CACHE_TYPE = 'FileSystemCache'

--- a/cravat/gui/store/handlers.py
+++ b/cravat/gui/store/handlers.py
@@ -8,6 +8,7 @@ from cravat.admin_util import InstallProgressJson
 from flask import request, current_app, jsonify, g
 from cravat import constants, admin_util as au, store_utils as su
 from cravat.gui.models import Module
+from cravat.gui.config import QUEUE_MODULE_INSTALL
 from cravat.gui.job_manager import queue_messages
 from cravat.gui.admin import is_admin_loggedin
 from cravat.gui.cravat_request import HTTP_BAD_REQUEST
@@ -211,7 +212,7 @@ def kill_install():
     module = request.values.get('module', None)
 
     # payload[0] is the job arguments, payload[0][0] is the first argument
-    install_jobs = queue_messages('module_install', lambda m: m.payload[0][0] == module)
+    install_jobs = queue_messages(QUEUE_MODULE_INSTALL, lambda m: m.payload[0][0] == module)
 
     # there should only be one, but if we happen to somehow have multiples
     # in the queue, kill them all.

--- a/cravat/gui/tasks.py
+++ b/cravat/gui/tasks.py
@@ -3,6 +3,7 @@ import subprocess
 from celery import shared_task, signals
 from cravat import admin_util
 from cravat.gui.api.live_module_cache import LiveModuleCache
+from cravat.gui.config import QUEUE_MODULE_INSTALL, QUEUE_LIVE_ANNOTATE, celery_settings
 from .api import live_annotate_worker
 from .models import Module
 from pathlib import Path
@@ -12,7 +13,7 @@ def run_job(run_args):
     subprocess.run(run_args)
 
 
-@shared_task(queue="module_install")
+@shared_task(queue=QUEUE_MODULE_INSTALL)
 def install_module(module_name, version, use_json_handler=None):
     admin_util.install_module(module_name, version=version, use_json_handler=use_json_handler)
     Module.invalidate_cache()
@@ -24,15 +25,14 @@ def run_report(db_path, report_type, tmp_flag_path):
     Path(tmp_flag_path).unlink()
 
 live_mapper = None
-enable_variant_api = admin_util.get_system_conf().get('enable_variant_api', False)
-if enable_variant_api:
+if celery_settings()[QUEUE_LIVE_ANNOTATE]['enabled']:
     @signals.worker_process_init.connect
     def _init_worker_state(**_):
         print(_)
         global live_mapper
         live_mapper = LiveModuleCache()
 
-    @shared_task(queue="live_annotate")
+    @shared_task(queue=QUEUE_LIVE_ANNOTATE)
     def api_live_annotate(queries, annotators, is_multiuser=False):
         global live_mapper
         return live_annotate_worker(queries, annotators, is_multiuser, live_mapper)

--- a/cravat/gui/workers.py
+++ b/cravat/gui/workers.py
@@ -1,0 +1,39 @@
+import sys
+
+from cravat.gui.config import (
+    QUEUE_DEFAULT,
+    QUEUE_MODULE_INSTALL,
+    QUEUE_LIVE_ANNOTATE,
+    celery_settings,
+)
+
+
+def _start(queue):
+    from cravat.gui import celery
+    n = celery_settings()[queue]['concurrency']
+    celery.Worker(queues=[queue], concurrency=n).start()
+
+
+def default_worker():
+    _start(QUEUE_DEFAULT)
+
+
+def store_worker():
+    _start(QUEUE_MODULE_INSTALL)
+
+
+def live_annotation_worker():
+    _start(QUEUE_LIVE_ANNOTATE)
+
+
+_WORKERS = {
+    'default': default_worker,
+    'store': store_worker,
+    'live': live_annotation_worker,
+}
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2 or sys.argv[1] not in _WORKERS:
+        sys.exit(f'usage: python -m cravat.gui.workers {{{"|".join(_WORKERS)}}}')
+    _WORKERS[sys.argv[1]]()

--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -22,8 +22,30 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 directory=/usr/local/lib/python3.13/site-packages/cravat
 
-[program:celery]
-command=celery -A cravat.gui.celery worker
+[program:celery-default]
+command=python -m cravat.gui.workers default
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+directory=/usr/local/lib/python3.13/site-packages/cravat
+user=www-data
+
+[program:celery-store]
+command=python -m cravat.gui.workers store
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+directory=/usr/local/lib/python3.13/site-packages/cravat
+user=www-data
+
+[program:celery-live]
+command=python -m cravat.gui.workers live
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
- Run three celery instances in Dockerfile.nginx supervisor
- Move worker launch functions to cravat/gui/workers.py so oc gui and
supervisor share one entry point. 
- Consolidate celery settings under a single block in cravat-system.yml
- Harmonize queue names via constants in config.py
- Fix worker queue subscription so each worker consumes only its own queue.