### PR TITLE
Add option for job id in send-gui

### DIFF
--- a/cravat/cravat_util.py
+++ b/cravat/cravat_util.py
@@ -684,25 +684,31 @@ def migrate_result(args):
 def result2gui(args):
     dbpath = args.path
     user = args.user
+    job_id = args.jobid
     jobs_dir = Path(au.get_jobs_dir())
     user_dir = jobs_dir / user
     if not user_dir.is_dir():
         exit(f"User {user} not found")
     attempts = 0
-    while (
-        True
-    ):  # TODO this will currently overwrite if called in parallel. is_dir check and creation is not atomic
-        job_id = datetime.datetime.now().strftime(r"%y%m%d-%H%M%S")
+    if job_id is None:
+        while (
+            True
+        ):  # TODO this will currently overwrite if called in parallel. is_dir check and creation is not atomic
+            job_id = datetime.datetime.now().strftime(r"%y%m%d-%H%M%S")
+            job_dir = user_dir / job_id
+            if not job_dir.is_dir():
+                break
+            else:
+                attempts += 1
+                time.sleep(1)
+            if attempts >= 5:
+                exit(
+                    "Could not acquire a job id. Too many concurrent job submissions. Wait, or reduce submission frequency."
+                )
+    else:
         job_dir = user_dir / job_id
-        if not job_dir.is_dir():
-            break
-        else:
-            attempts += 1
-            time.sleep(1)
-        if attempts >= 5:
-            exit(
-                "Could not acquire a job id. Too many concurrent job submissions. Wait, or reduce submission frequency."
-            )
+        if job_dir.is_dir():
+            exit(f"Job id {job_id} you selected already exists. Please select another one.")
     job_dir.mkdir()
     new_dbpath = job_dir / dbpath.name
     shutil.copyfile(dbpath, new_dbpath)
@@ -1187,6 +1193,13 @@ parser_result2gui.add_argument(
     help="User who will own the job. Defaults to single user default user.",
     type=str,
     default="default",
+)
+parser_result2gui.add_argument(
+    "-j",
+    "--jobid",
+    help="Optional job ID. Defaults to current timestamp",
+    type=str,
+    default=None,
 )
 parser_result2gui.set_defaults(func=result2gui)
 # Merge SQLite files


### PR DESCRIPTION
This adds optional argument to set custom (not a timestamp) jobid when using `oc util send-gui`

Rationale: when submitting many jobs via CLI it is sometimes inconvenient to have somewhat random job id (as it is now, with +- couple seconds undetermined). It also can be used for explicit use of job_id parameter in open-cravat links

New command usage:
`oc util send-gui <sample>.sqlite -j <jobid>`
if no jobid is specified, will have current default behaviour (try to create timestamp)

<img width="235" height="149" alt="image" src="https://github.com/user-attachments/assets/0cdd1340-18ad-4c10-9feb-c4493b6a6fad" />

<img width="389" height="54" alt="image" src="https://github.com/user-attachments/assets/c4d4904f-9a44-4aa9-8802-120ba58a1061" />
